### PR TITLE
Add Open Spaces page

### DIFF
--- a/src/content/pages/open-spaces.md
+++ b/src/content/pages/open-spaces.md
@@ -1,0 +1,59 @@
+---
+title: EuroPython 2025 Open Spaces
+subtitle: Organise or join an open space at EuroPython 2025!
+---
+
+# EuroPython 2025 Open Spaces
+
+At EuroPython 2025, Open Spaces offer a unique opportunity for attendees to
+shape their own experience. Instead of fixed schedules and talks, these sessions are
+run by participants like you who bring fresh ideas and create discussions in an open
+and friendly environment.
+
+During the main days of the conference, two rooms will be dedicated to Open Spaces,
+with enough space for everyone to delve into the topics that interest them most.
+
+## What is an Open Space?
+
+Open Spaces are participant-driven gatherings where anyone can propose a topic,
+lead a discussion or presentation, and collaborate with others. Attendees can add
+their session idea to the Open Spaces registration calendar, which also serves to
+attract potential participants interested in joining.
+
+Check the [Open Spaces schedule ↗️!](https://calendar.google.com/calendar/u/0?cid=Y19iODcwNzViMjljZjRhOWRkNGRhM2ZlNzI0ZmNiYTkyYTRiNDA2YWEzZjkxY2I3ZTdjZTUwZmVkZTQzMjE1YjE3QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
+
+## How to Organize an Open Space
+
+To organize your own Open Space session, simply book a free time slot and room via
+our [Open Spaces registration calendar](https://calendar.google.com/calendar/u/0?cid=Y19iODcwNzViMjljZjRhOWRkNGRhM2ZlNzI0ZmNiYTkyYTRiNDA2YWEzZjkxY2I3ZTdjZTUwZmVkZTQzMjE1YjE3QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) — this allows you to easily secure a space to
+host your discussion or presentation.
+
+Both Room 221+222 and Room 223+224 will be reserved exclusively for Open Space sessions.
+You can book either space by using the links below:
+
+[Room 221+222](https://calendar.app.google/6nb3VqFGf6j5vT7f8) | [Room 223+224](https://calendar.app.google/i8bspsBUZ4AapNZ98)
+
+## Who Can Participate?
+
+Anyone attending EuroPython 2025 can join or lead an Open Space session. It’s
+a perfect opportunity to share your ideas, ask questions, and connect with
+others around topics you’re passionate about!
+
+## Possible Topics
+
+Open Space sessions can cover a wide range of topics, such as:
+
+- New Python features
+- Python in hardware, IoT, or automation
+- Data science and AI
+- Web frameworks and microservices
+- Machine learning applications
+- Improving code quality
+- Community building and diversity in tech
+- Open source contributions
+- Mentoring
+- Career growth and personal development
+
+… and anything else you want to explore together!
+
+


### PR DESCRIPTION
This PR adds a new page for Open Spaces (based on the existing Sprints page) with the main info and the digitalized system to make bookings